### PR TITLE
bug #30: fix new VID/PID name

### DIFF
--- a/stage2/05-reachy-mini/files/99-respeaker.rules
+++ b/stage2/05-reachy-mini/files/99-respeaker.rules
@@ -1,2 +1,5 @@
 # usb 4mic array
 SUBSYSTEM=="usb", ATTR{idVendor}=="2886", ATTR{idProduct}=="001a", MODE="0666"
+
+# reachy mini audio 
+SUBSYSTEM=="usb", ATTR{idVendor}=="38FB", ATTR{idProduct}=="1001", MODE="0666"

--- a/stage2/05-reachy-mini/files/reachyminios_check.sh
+++ b/stage2/05-reachy-mini/files/reachyminios_check.sh
@@ -47,14 +47,14 @@ for plugin in webrtcsrc webrtcsink; do
 	fi
 done
 
-# Get ReSpeaker version
+# Get Reachy Mini Audio version
 if command -v xvf_host > /dev/null 2>&1; then
 	VERSION_OUTPUT=$(xvf_host VERSION 2>&1)
 	VERSION_LINE=$(echo "$VERSION_OUTPUT" | grep '^VERSION')
 	if [ -n "$VERSION_LINE" ]; then
-		echo -e "OK: ReSpeaker VERSION: $VERSION_LINE \e[32m✔\e[0m"
+		echo -e "OK: Reachy Mini Audio VERSION: $VERSION_LINE \e[32m✔\e[0m"
 	else
-	echo -e "ERROR: Could not determine ReSpeaker version from xvf_host output. \e[31m✘\e[0m"
+	echo -e "ERROR: Could not determine Reachy Mini Audio version from xvf_host output. \e[31m✘\e[0m"
 		EXIT_CODE=1
 	fi
 else
@@ -62,11 +62,11 @@ else
 	EXIT_CODE=1
 fi
 
-# Test ReSpeaker audio output
-echo "Testing ReSpeaker audio output..."
-CARD_NUM=$(aplay -l | awk '/reSpeaker XVF3800 4-Mic Array/ {for(i=1;i<=NF;i++) if ($i=="card") {val=$(i+1); sub(":$", "", val); print val}}' | head -n1)
+# Test Reachy Mini Audio audio output
+echo "Testing Reachy Mini Audio audio output..."
+CARD_NUM=$(aplay -l | awk '/Pollen Robotics Reachy Mini Audio/ {for(i=1;i<=NF;i++) if ($i=="card") {val=$(i+1); sub(":$", "", val); print val}}' | head -n1)
 if [ -n "$CARD_NUM" ]; then
-	echo -e "OK: Found ReSpeaker audio card number: $CARD_NUM \e[32m✔\e[0m"
+	echo -e "OK: Found Reachy Mini Audio audio card number: $CARD_NUM \e[32m✔\e[0m"
 	# Set volume to 100% before testing
 	if amixer -c $CARD_NUM sset 'PCM' 100% > /dev/null 2>&1 && amixer -c $CARD_NUM sset 'PCM,1' 100% > /dev/null 2>&1; then
 		echo -e "OK: Set volume to 100% for card $CARD_NUM (PCM and PCM,1) \e[32m✔\e[0m"
@@ -77,12 +77,12 @@ if [ -n "$CARD_NUM" ]; then
 	echo "Playing test sound..."
 	timeout 2s speaker-test -Dplughw:$CARD_NUM > /tmp/speaker_test.txt 2>&1
 else
-	echo -e "ERROR: ReSpeaker audio card not found. \e[31m✘\e[0m"
+	echo -e "ERROR: Reachy Mini Audio audio card not found. \e[31m✘\e[0m"
 	EXIT_CODE=1
 fi
 
-# Test ReSpeaker audio recording
-echo "Testing ReSpeaker audio recording with arecord..."
+# Test Reachy Mini Audio audio recording
+echo "Testing Reachy Mini Audio audio recording with arecord..."
 WAV_PATH="/tmp/test.wav"
 rm -f "$WAV_PATH"
 if [ -n "$CARD_NUM" ]; then
@@ -94,7 +94,7 @@ if [ -n "$CARD_NUM" ]; then
 		EXIT_CODE=1
 	fi
 else
-	echo -e "ERROR: ReSpeaker audio card not found for recording. \e[31m✘\e[0m"
+	echo -e "ERROR: Reachy Mini Audio audio card not found for recording. \e[31m✘\e[0m"
 	EXIT_CODE=1
 fi
 

--- a/stage2/05-reachy-mini/files/reachyminios_check.sh
+++ b/stage2/05-reachy-mini/files/reachyminios_check.sh
@@ -47,24 +47,24 @@ for plugin in webrtcsrc webrtcsink; do
 	fi
 done
 
-# Get Reachy Mini Audio version
-if command -v xvf_host > /dev/null 2>&1; then
-	VERSION_OUTPUT=$(xvf_host VERSION 2>&1)
-	VERSION_LINE=$(echo "$VERSION_OUTPUT" | grep '^VERSION')
-	if [ -n "$VERSION_LINE" ]; then
-		echo -e "OK: Reachy Mini Audio VERSION: $VERSION_LINE \e[32m✔\e[0m"
+# Get Reachy Mini Audio version using dfu-util
+if command -v dfu-util > /dev/null 2>&1; then
+	DFU_OUTPUT=$(dfu-util -l 2>/dev/null)
+	VERSION_NUM=$(echo "$DFU_OUTPUT" | grep -m1 'Found DFU:' | sed -n 's/.*ver=\([0-9][0-9]*\),.*/\1/p')
+	if [ -n "$VERSION_NUM" ]; then
+		echo -e "OK: Reachy Mini Audio DFU version: $VERSION_NUM \e[32m✔\e[0m"
 	else
-	echo -e "ERROR: Could not determine Reachy Mini Audio version from xvf_host output. \e[31m✘\e[0m"
+		echo -e "ERROR: Could not determine Reachy Mini Audio version from dfu-util output. \e[31m✘\e[0m"
 		EXIT_CODE=1
 	fi
 else
-	echo -e "ERROR: xvf_host command not found. \e[31m✘\e[0m"
+	echo -e "ERROR: dfu-util command not found. \e[31m✘\e[0m"
 	EXIT_CODE=1
 fi
 
 # Test Reachy Mini Audio audio output
 echo "Testing Reachy Mini Audio audio output..."
-CARD_NUM=$(aplay -l | awk '/Pollen Robotics Reachy Mini Audio/ {for(i=1;i<=NF;i++) if ($i=="card") {val=$(i+1); sub(":$", "", val); print val}}' | head -n1)
+CARD_NUM=$(aplay -l | awk '/Reachy Mini Audio/ {for(i=1;i<=NF;i++) if ($i=="card") {val=$(i+1); sub(":$", "", val); print val}}' | head -n1)
 if [ -n "$CARD_NUM" ]; then
 	echo -e "OK: Found Reachy Mini Audio audio card number: $CARD_NUM \e[32m✔\e[0m"
 	# Set volume to 100% before testing


### PR DESCRIPTION
Can you try this new script please?

copy this file
https://github.com/pollen-robotics/reachy-mini-os/blob/30-wrong-vidpid/stage2/05-reachy-mini/files/99-respeaker.rules
to `/etc/udev/rules.d/`

then `sudo udevadm control --reload-rules && udevadm trigger`

copy this somewhere
https://github.com/pollen-robotics/reachy-mini-os/blob/30-wrong-vidpid/stage2/05-reachy-mini/files/reachyminios_check.sh
```
chmod +x reachyminios_check.sh
./reachyminios_check.sh
```