### PR TITLE
enhancement #45: update plugins

### DIFF
--- a/stage2/05-reachy-mini/files/gst-plugins-rs-rpi.tar.gz
+++ b/stage2/05-reachy-mini/files/gst-plugins-rs-rpi.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02a03889e2b53e0986d94a5207bd28bc4835fde1bb3355d1bdb118e09065e4e6
-size 107018488
+oid sha256:7630265f09d9f35c81d450eca7a8a291e3d5b4e7c7fcc43ccf05ed144cf64376
+size 85935458


### PR DESCRIPTION
Test reachy mini as usual it should not change anything.
There is a bug fix in the plugin that will be useful for a future feature.

I've added the plugin tracers for internal analysis. So you can test the plugin is up to date doing this:
`gst-inspect-1.0 rstracers`

If it finds something it ok!