### PR TITLE
enhancement #47: pipewire packages

### DIFF
--- a/stage2/01-sys-tweaks/00-packages-nr
+++ b/stage2/01-sys-tweaks/00-packages-nr
@@ -33,3 +33,6 @@ dfu-util
 git
 git-lfs
 i2c-tools
+gstreamer1.0-pipewire
+libspa-0.2-libcamera
+pipewire-audio


### PR DESCRIPTION
you can do this in the current install to test
`sudo apt install pipewire-audio libspa-0.2-libcamera gstreamer1.0-pipewire`

After a reboot, this command
`gst-device-monitor-1.0 Audio`
will show something like
`gst-launch-1.0 ... ! pipewiresink target-object=70`

We'll still use the direct access to alsa and libcamera for now, so the daemon should work as usual. But pipewire could be a better option to share audio video among multiple clients.