### PR TITLE
CM4 fan noise fix

### DIFF
--- a/stage1/00-boot-files/files/config.txt
+++ b/stage1/00-boot-files/files/config.txt
@@ -58,7 +58,7 @@ enable_uart=1
 dtparam=ant2
 # Fan i2c
 dtparam=i2c_vc=on
-dtoverlay=i2c-fan,emc2301,i2c_csi_dsi,midtemp=45000,maxtemp=65000
+dtoverlay=i2c-fan,emc2301,i2c_csi_dsi,midtemp=55000,maxtemp=65000
 # Camera
 dtoverlay=imx708,rotation=0,cam1
 dtoverlay=imx708,rotation=0,cam0


### PR DESCRIPTION
The original threshold of 45 degrees Celsius caused the fan to spin up often and exhibited a noisy behaviour.

A threshold of 55 will keep Reachy well within CM4's temperature limits (throttling starts at 80 degrees). At a room temperature of 23 degrees Celsius, ReachyMini wireless will run at normal loads (conversation app active) without the fan even spinning most of the time.

In case you'd like to adapt to your needs: install lm-sensors package via console/apt and check temps with 'sensors'. Modify the 'midtemp' value in /boot/firmware/config.txt