### PR TITLE
stage2: grant pollen scoped passwordless sudo

### DIFF
--- a/stage2/05-reachy-mini/00-run.sh
+++ b/stage2/05-reachy-mini/00-run.sh
@@ -31,6 +31,7 @@ Cmnd_Alias REACHY = \
     /usr/sbin/rfkill unblock bluetooth, \
     /usr/sbin/rfkill unblock wifi, \
     /usr/sbin/shutdown -h now, \
+    /usr/bin/chown pollen\:pollen -R /venvs, \
     /bluetooth/commands/HOTSPOT.sh, \
     /bluetooth/commands/WIFI_RESET.sh, \
     /bluetooth/commands/SOFTWARE_RESET.sh, \

--- a/stage2/05-reachy-mini/00-run.sh
+++ b/stage2/05-reachy-mini/00-run.sh
@@ -9,6 +9,40 @@ echo "GStreamer plugins installed."
 echo "Setting up udev rules for respeaker mic array..."
 cp files/99-respeaker.rules ${ROOTFS_DIR}/etc/udev/rules.d/
 
+# raspberrypi-sys-mods >= 1:20251028+1 removes /etc/sudoers.d/010_pi-nopasswd
+# (its postinst calls dpkg-maintscript-helper rm_conffile). Reachy creates the
+# pollen user at build time, bypassing the Imager/firstboot userconf flow that
+# would otherwise grant passwordless sudo, so pollen ends up without it. The
+# reachy daemons run as pollen with no TTY and rely on sudo for a handful of
+# privileged operations, which breaks WiFi and Bluetooth when sudo prompts.
+#
+# Grant ONLY the exact command vectors the daemon needs. Do NOT grant blanket
+# NOPASSWD or bare /usr/bin/systemctl: that is a trivial local root escalation
+# via `systemctl link` of an attacker-controlled unit whose ExecStart runs as
+# root. Pinning each command to fixed arguments removes the escalation
+# primitive. NOTE: the /bluetooth/commands/*.sh scripts MUST remain root-owned
+# and non-pollen-writable, or this scoping is bypassable.
+echo "Granting pollen scoped passwordless sudo..."
+install -d -m 0755 "${ROOTFS_DIR}/etc/sudoers.d"
+cat > "${ROOTFS_DIR}/etc/sudoers.d/010-pollen-reachy" <<'EOF'
+Cmnd_Alias REACHY = \
+    /usr/bin/systemctl restart reachy-mini-daemon, \
+    /usr/bin/systemctl restart reachy-mini-bluetooth, \
+    /usr/sbin/rfkill unblock bluetooth, \
+    /usr/sbin/rfkill unblock wifi, \
+    /usr/sbin/shutdown -h now, \
+    /bluetooth/commands/HOTSPOT.sh, \
+    /bluetooth/commands/WIFI_RESET.sh, \
+    /bluetooth/commands/SOFTWARE_RESET.sh, \
+    /bluetooth/commands/RESTART_DAEMON.sh
+pollen ALL=(root) NOPASSWD: REACHY
+EOF
+chmod 0440 "${ROOTFS_DIR}/etc/sudoers.d/010-pollen-reachy"
+# Fail the build if the sudoers file is malformed (a bad file locks out sudo).
+on_chroot <<- EOF
+	visudo -cf /etc/sudoers.d/010-pollen-reachy
+EOF
+
 echo "Creating VERSION.txt file..."
 rm ${ROOTFS_DIR}/home/pollen/VERSION.txt
 echo "ReachyMiniOS: dev" > ${ROOTFS_DIR}/home/pollen/VERSION.txt


### PR DESCRIPTION
raspberrypi-sys-mods >= 1:20251028+1 removes /etc/sudoers.d/010_pi-nopasswd, which the reachy pollen daemon user relied on. The daemon runs as pollen with no TTY and uses sudo for rfkill, the BLE command scripts, shutdown, and restarting its own services, so without passwordless sudo WiFi and Bluetooth both fail.

Install a scoped sudoers drop-in granting pollen NOPASSWD for only the exact command vectors the daemon invokes, under a reachy-owned filename so the base package's rm_conffile never removes it. A blanket grant or bare /usr/bin/systemctl is avoided as it would allow local root escalation via `systemctl link`. The build runs visudo -cf to fail fast on a malformed file.

Assisted-by: Claude:claude-opus-4-7