### PR TITLE
Update GStreamer libs and install custom libcamera

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 [attr]lfs -text filter=lfs diff=lfs merge=lfs
 
 *.gz lfs
+*.xz lfs

--- a/stage2/01-sys-tweaks/00-packages-nr
+++ b/stage2/01-sys-tweaks/00-packages-nr
@@ -20,7 +20,6 @@ gstreamer1.0-plugins-base-apps
 libgstreamer1.0-dev
 libglib2.0-dev
 libssl-dev
-gstreamer1.0-libcamera
 librpicam-app1
 libnice10
 gstreamer1.0-plugins-good
@@ -34,5 +33,4 @@ git
 git-lfs
 i2c-tools
 gstreamer1.0-pipewire
-libspa-0.2-libcamera
 pipewire-audio

--- a/stage2/05-reachy-mini/00-run.sh
+++ b/stage2/05-reachy-mini/00-run.sh
@@ -3,7 +3,21 @@
 echo "Installing GStreamer plugins..."
 tar -xzf files/gst-plugins-rs-rpi.tar.gz -C ${ROOTFS_DIR}/
 # Set environment variable for GStreamer plugins
-echo 'export GST_PLUGIN_PATH=/opt/gst-plugins-rs/lib/aarch64-linux-gnu/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
+
+echo "Updating GStreamer libs..."
+tar -xzf files/gstvideo4linux2_custom.tar.gz -C ${ROOTFS_DIR}/tmp
+mv ${ROOTFS_DIR}/tmp/libgstpbutils-1.0.so.0.2602.0 ${ROOTFS_DIR}/usr/lib/aarch64-linux-gnu/libgstpbutils-1.0.so.0.2602.0
+mv ${ROOTFS_DIR}/tmp/libgstvideo4linux2.so ${ROOTFS_DIR}/usr/lib/aarch64-linux-gnu/gstreamer-1.0/libgstvideo4linux2.so
+ln -sf libgstpbutils-1.0.so.0.2602.0 ${ROOTFS_DIR}/usr/lib/aarch64-linux-gnu/libgstpbutils-1.0.so
+ln -sf libgstpbutils-1.0.so.0.2602.0 ${ROOTFS_DIR}/usr/lib/aarch64-linux-gnu/libgstpbutils-1.0.so.0
+
+echo "Installing custom libcamera"
+tar -xzf files/libcamera_custom.tar.gz -C ${ROOTFS_DIR}/usr/local
+
+echo 'export GST_PLUGIN_PATH=/opt/gst-plugins-rs/lib/aarch64-linux-gnu/:/usr/local/lib/aarch64-linux-gnu/gstreamer-1.0/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
+echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/aarch64-linux-gnu/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
+echo 'export LIBCAMERA_IPA_MODULE_PATH=/usr/local/lib/aarch64-linux-gnu/libcamera/ipa' >> ${ROOTFS_DIR}/home/pollen/.bashrc
+echo 'export LIBCAMERA_IPA_CONFIG_PATH=/usr/local/share/libcamera/ipa' >> ${ROOTFS_DIR}/home/pollen/.bashrc
 echo "GStreamer plugins installed."
 
 echo "Setting up udev rules for respeaker mic array..."

--- a/stage2/05-reachy-mini/00-run.sh
+++ b/stage2/05-reachy-mini/00-run.sh
@@ -14,7 +14,7 @@ ln -sf libgstpbutils-1.0.so.0.2602.0 ${ROOTFS_DIR}/usr/lib/aarch64-linux-gnu/lib
 echo "Installing custom libcamera"
 tar -xzf files/libcamera_custom.tar.gz -C ${ROOTFS_DIR}/usr/local
 
-echo 'export GST_PLUGIN_PATH=/opt/gst-plugins-rs/lib/aarch64-linux-gnu/:/usr/local/lib/aarch64-linux-gnu/gstreamer-1.0/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
+echo 'export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:/opt/gst-plugins-rs/lib/aarch64-linux-gnu/:/usr/local/lib/aarch64-linux-gnu/gstreamer-1.0/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
 echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/aarch64-linux-gnu/' >> ${ROOTFS_DIR}/home/pollen/.bashrc
 echo 'export LIBCAMERA_IPA_MODULE_PATH=/usr/local/lib/aarch64-linux-gnu/libcamera/ipa' >> ${ROOTFS_DIR}/home/pollen/.bashrc
 echo 'export LIBCAMERA_IPA_CONFIG_PATH=/usr/local/share/libcamera/ipa' >> ${ROOTFS_DIR}/home/pollen/.bashrc

--- a/stage2/05-reachy-mini/files/gst-plugins-rs-rpi.tar.gz
+++ b/stage2/05-reachy-mini/files/gst-plugins-rs-rpi.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7630265f09d9f35c81d450eca7a8a291e3d5b4e7c7fcc43ccf05ed144cf64376
-size 85935458
+oid sha256:0dbe67095eb44969270bcb54c1de5ae696bc709adcec7a7f5b60935fe86d7ae8
+size 86733914

--- a/stage2/05-reachy-mini/files/gstvideo4linux2_custom.tar.gz
+++ b/stage2/05-reachy-mini/files/gstvideo4linux2_custom.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3bee1e05bfe2d3ee5ba30b8b977389fe4a9ef87ddc4a2a2b66dfb77796a033
+size 1081940

--- a/stage2/05-reachy-mini/files/libcamera_custom.tar.gz
+++ b/stage2/05-reachy-mini/files/libcamera_custom.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6492859a08593b5efb9fe8775690d20b6088231c69cdade64cff7a7b1e02327f
+size 3096382


### PR DESCRIPTION
Drop distro gstreamer1.0-libcamera/libspa-0.2-libcamera packages in favor of custom builds shipped as tarballs: refreshed gst-plugins-rs, new gstvideo4linux2/libgstpbutils overlay, and a libcamera install under /usr/local. Wire up GST/LD/LIBCAMERA env vars in the pollen user's .bashrc, and fix the libgstpbutils symlinks to use relative targets so they resolve on the booted device rather than the build host's ROOTFS_DIR path.

Assisted-by: Claude:claude-opus-4-7