### PR TITLE
stage2: enable git LFS for uv system-wide

### DIFF
--- a/stage2/05-reachy-mini/00-run.sh
+++ b/stage2/05-reachy-mini/00-run.sh
@@ -9,6 +9,19 @@ echo "GStreamer plugins installed."
 echo "Setting up udev rules for respeaker mic array..."
 cp files/99-respeaker.rules ${ROOTFS_DIR}/etc/udev/rules.d/
 
+echo "Enabling Git LFS for uv system-wide (issue #56)..."
+# Login shells, PAM sessions, and user-scope systemd.
+grep -qxF 'UV_GIT_LFS=1' "${ROOTFS_DIR}/etc/environment" \
+    || echo 'UV_GIT_LFS=1' >> "${ROOTFS_DIR}/etc/environment"
+# System-scope systemd services (reachy-mini-daemon et al. run as User=pollen
+# at the system level and do NOT inherit /etc/environment).
+install -d -m 0755 "${ROOTFS_DIR}/etc/systemd/system.conf.d"
+cat > "${ROOTFS_DIR}/etc/systemd/system.conf.d/10-uv-git-lfs.conf" <<'EOF'
+# reachy-mini-os#56: make uv respect Git LFS in system services that invoke it.
+[Manager]
+DefaultEnvironment="UV_GIT_LFS=1"
+EOF
+
 echo "Creating VERSION.txt file..."
 rm ${ROOTFS_DIR}/home/pollen/VERSION.txt
 echo "ReachyMiniOS: dev" > ${ROOTFS_DIR}/home/pollen/VERSION.txt


### PR DESCRIPTION
Fixes #56. uv skips Git LFS objects by default, so any uv-installed dependency tracked via LFS (model weights, audio assets, etc.) lands as pointer files instead of real content. Set UV_GIT_LFS=1 in /etc/environment for interactive/login sessions, and via /etc/systemd/system.conf.d/ for system-level services like reachy-mini-daemon (which run as User=pollen but at the system scope and therefore don't inherit /etc/environment).

Assisted-by: Claude:claude-opus-4-7