### PR TITLE
ci: fix qemu dependency and bump workflow actions

### DIFF
--- a/.github/workflows/generate_img.yml
+++ b/.github/workflows/generate_img.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             lfs: true
 
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y coreutils quilt parted qemu-user-static debootstrap zerofree zip \
+          sudo apt-get install -y coreutils quilt parted qemu-user-binfmt debootstrap zerofree zip \
             dosfstools e2fsprogs libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc \
             gpg pigz xxd arch-test bmap-tools kmod
 
@@ -47,13 +47,13 @@ jobs:
           TAG: ${{ env.TAG }}
 
       - name: Upload generated image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: reachyminios-image-${{ env.TAG }}
             path: deploy/*
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
         with:
             files: deploy/*


### PR DESCRIPTION
build.sh requires the qemu-arm binary (package qemu-user-binfmt) after the upstream pi-gen depends change, but the workflow still installed qemu-user-static, so tag builds failed the dependency check with "Required dependencies not installed: qemu-user-binfmt".

Switch the apt install to qemu-user-binfmt to match depends, and bump the workflow actions: checkout v4->v6, upload-artifact v4->v7, softprops/action-gh-release v2->v3.

Assisted-by: Claude:claude-opus-4-8