### PR TITLE
ci: use qemu-user-static for arm64 chroot bootstrap

### DIFF
--- a/.github/workflows/generate_img.yml
+++ b/.github/workflows/generate_img.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y coreutils quilt parted qemu-user-binfmt debootstrap zerofree zip \
+          sudo apt-get install -y coreutils quilt parted qemu-user-static debootstrap zerofree zip \
             dosfstools e2fsprogs libarchive-tools libcap2-bin grep rsync xz-utils file git curl bc \
             gpg pigz xxd arch-test bmap-tools kmod
 

--- a/depends
+++ b/depends
@@ -1,7 +1,7 @@
 quilt
 parted
 realpath:coreutils
-qemu-arm:qemu-user-binfmt
+qemu-arm-static:qemu-user-static
 debootstrap
 zerofree
 zip

--- a/scripts/dependencies_check
+++ b/scripts/dependencies_check
@@ -3,7 +3,7 @@
 #
 # Each dependency is in the form of a tool to test for, optionally followed by
 # a : and the name of a package if the package on a Debian-ish system is not
-# named for the tool (i.e., qemu-user-binfmt).
+# named for the tool (i.e., qemu-user-static).
 dependencies_check()
 {
 	local depfile deps missing


### PR DESCRIPTION
PR #69 made the dependency check pass by installing qemu-user-binfmt, but the build then failed in debootstrap with "Unable to execute target architecture": qemu-user-binfmt registers the dynamically-linked qemu-arm, which cannot run inside the bootstrap chroot because its shared libraries are absent there.

The cross arm64 debootstrap second stage runs ARM binaries inside the chroot via binfmt_misc, so it needs the statically-linked interpreter from qemu-user-static (qemu-arm-static). Revert the upstream pi-gen depends change (qemu-arm:qemu-user-binfmt -> qemu-arm-static:qemu-user-static) and install qemu-user-static in CI again. This restores the exact qemu config that built v0.2.3 successfully.

Note: this re-diverges from upstream pi-gen's depends. A future upstream merge may re-introduce qemu-user-binfmt and re-break the build inside the chroot; do not re-apply that change.

Assisted-by: Claude:claude-opus-4-8