### PR TITLE
Add missing preferences.pin-kernel file

### DIFF
--- a/stage0/00-configure-apt/files/preferences.pin-kernel
+++ b/stage0/00-configure-apt/files/preferences.pin-kernel
@@ -1,0 +1,11 @@
+# Pin the Raspberry Pi kernel to 6.18.33.
+#
+# 6.18.34 broke BLE advertising on Reachy Mini, so the kernel must stay at
+# 6.18.33 even though stage0/00-configure-apt runs `apt-get dist-upgrade -y`
+# and later stages install/upgrade packages. This pin keeps every kernel
+# image/header package at the 6.18.33-1+rpt1 release and refuses any newer
+# candidate (Pin-Priority 1001 > 1000 also allows a downgrade if a newer one
+# already slipped in).
+Package: linux-image-* linux-headers-* linux-kbuild-*
+Pin: version 1:6.18.33-1+rpt1
+Pin-Priority: 1001


### PR DESCRIPTION
## Problem

The v0.2.7 build (tag, built from `develop`) fails in stage0:

```
install: cannot stat 'files/preferences.pin-kernel': No such file or directory
[..] Build failed
```

Failed run: https://github.com/pollen-robotics/reachy-mini-os/actions/runs/27667913758/job/81825648480

Commit 2f9724a ("pin to kernel 6.18.33") added an `install files/preferences.pin-kernel` line to `stage0/00-configure-apt/00-run.sh` and pinned the kernel packages to 6.18.33 in `02-firmware/01-packages`, but never committed the referenced pin file. The `install` then fails and aborts the whole build.

## Fix

Adds the missing `stage0/00-configure-apt/files/preferences.pin-kernel`. It uses a wildcard pin so the `apt-get dist-upgrade -y` that runs right after in the same script (and later stages) keep the kernel at 6.18.33-1+rpt1 — 6.18.34 broke BLE advertising.

```
Package: linux-image-* linux-headers-* linux-kbuild-*
Pin: version 1:6.18.33-1+rpt1
Pin-Priority: 1001
```

## To verify

- [ ] Confirm `1:6.18.33-1+rpt1` is the exact version string in the RPi archive (so the pin matches).
- [ ] CI build passes.

Assisted-by: Claude:claude-opus-4-8