### PR TITLE
ci: mirror OS release images to Hugging Face dataset

### DIFF
--- a/.github/scripts/mirror_to_hf.py
+++ b/.github/scripts/mirror_to_hf.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Mirror a ReachyMiniOS GitHub release to the Hugging Face dataset.
+
+Downloads the release assets (image + .bmap + .info) and uploads them to
+`HF_DATASET` under `<tag>/<filename>`, then writes a top-level `latest.json`
+manifest the desktop flasher reads to know what to download.
+
+Idempotent: assets already present on HF for that tag are skipped.
+
+Env:
+  HF_TOKEN      Hugging Face write token (required)
+  HF_DATASET    e.g. "pollen-robotics/reachy-mini-os" (required)
+  GH_REPO       "owner/repo" of the OS releases (required)
+  RELEASE_TAG   tag to mirror; empty -> latest release
+  GITHUB_TOKEN  optional, raises GitHub API rate limits
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+import requests
+from huggingface_hub import HfApi
+
+GH_REPO = os.environ["GH_REPO"]
+HF_DATASET = os.environ["HF_DATASET"]
+HF_TOKEN = os.environ["HF_TOKEN"]
+RELEASE_TAG = os.environ.get("RELEASE_TAG", "").strip()
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+
+# Image asset preference order (first match wins).
+IMAGE_SUFFIXES = (".img.gz", ".zip", ".img")
+
+api = HfApi(token=HF_TOKEN)
+
+
+def gh_get(url: str) -> dict:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "reachy-mini-os-mirror",
+    }
+    if GITHUB_TOKEN:
+        headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    resp = requests.get(url, headers=headers, timeout=60)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def pick(assets: list[dict], suffixes: tuple[str, ...]) -> dict | None:
+    for suffix in suffixes:
+        for asset in assets:
+            if asset["name"].lower().endswith(suffix):
+                return asset
+    return None
+
+
+def download(url: str, dest: pathlib.Path) -> None:
+    print(f"  downloading {url}")
+    with requests.get(url, stream=True, timeout=180) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=8 * 1024 * 1024):
+                fh.write(chunk)
+
+
+def mirror_asset(asset: dict, tag: str, existing: set[str]) -> str:
+    name = asset["name"]
+    repo_path = f"{tag}/{name}"
+    if repo_path in existing:
+        print(f"  skip (already on HF): {repo_path}")
+        return repo_path
+    with tempfile.TemporaryDirectory() as tmp:
+        local = pathlib.Path(tmp) / name
+        download(asset["browser_download_url"], local)
+        print(f"  uploading -> {repo_path}")
+        api.upload_file(
+            path_or_fileobj=str(local),
+            path_in_repo=repo_path,
+            repo_id=HF_DATASET,
+            repo_type="dataset",
+            commit_message=f"Mirror {name} ({tag})",
+        )
+    return repo_path
+
+
+def main() -> int:
+    if RELEASE_TAG:
+        rel = gh_get(f"https://api.github.com/repos/{GH_REPO}/releases/tags/{RELEASE_TAG}")
+    else:
+        rel = gh_get(f"https://api.github.com/repos/{GH_REPO}/releases/latest")
+
+    tag = rel["tag_name"]
+    assets = rel.get("assets", [])
+    print(f"Mirroring {GH_REPO}@{tag} -> {HF_DATASET} ({len(assets)} assets)")
+
+    image_asset = pick(assets, IMAGE_SUFFIXES)
+    if not image_asset:
+        print("ERROR: no image asset (.img.gz/.zip/.img) in release", file=sys.stderr)
+        return 1
+    bmap_asset = pick(assets, (".bmap",))
+    info_asset = pick(assets, (".info",))
+
+    api.create_repo(HF_DATASET, repo_type="dataset", exist_ok=True)
+    existing = set(api.list_repo_files(HF_DATASET, repo_type="dataset"))
+
+    image_path = mirror_asset(image_asset, tag, existing)
+    bmap_path = mirror_asset(bmap_asset, tag, existing) if bmap_asset else None
+    if info_asset:
+        mirror_asset(info_asset, tag, existing)
+
+    manifest = {
+        "tag": tag,
+        "image": image_path,
+        "bmap": bmap_path,
+        "image_size": image_asset.get("size"),
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        manifest_file = pathlib.Path(tmp) / "latest.json"
+        manifest_file.write_text(json.dumps(manifest, indent=2) + "\n")
+        api.upload_file(
+            path_or_fileobj=str(manifest_file),
+            path_in_repo="latest.json",
+            repo_id=HF_DATASET,
+            repo_type="dataset",
+            commit_message=f"Update latest.json -> {tag}",
+        )
+
+    print("Done:", json.dumps(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/mirror-to-hf.yml
+++ b/.github/workflows/mirror-to-hf.yml
@@ -1,0 +1,51 @@
+name: Mirror release to Hugging Face
+
+# Mirrors ReachyMiniOS release assets to the Hugging Face dataset
+# `pollen-robotics/reachy-mini-os`, whose xet/LFS CDN is much faster to pull
+# than GitHub release downloads. The desktop flasher reads `latest.json` from
+# that dataset and downloads the image from there (GitHub stays as a fallback).
+#
+# Trigger: runs after "Generate ReachyMini OS Image" finishes (a release
+# published by the default GITHUB_TOKEN does NOT emit a `release` event, so we
+# key off the build workflow instead). Also runnable manually to backfill a tag.
+#
+# Setup (once): add a repo secret `HF_TOKEN` = a Hugging Face write token that
+# can push to the `pollen-robotics/reachy-mini-os` dataset.
+
+on:
+  workflow_run:
+    workflows: ["Generate ReachyMini OS Image"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to mirror (defaults to the latest release)"
+        required: false
+
+concurrency:
+  group: mirror-to-hf
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    # For workflow_run, only mirror after a successful build.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install "huggingface_hub[hf_xet]>=0.25" requests
+
+      - name: Mirror assets to Hugging Face
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HF_DATASET: pollen-robotics/reachy-mini-os
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
+        run: python .github/scripts/mirror_to_hf.py


### PR DESCRIPTION
## Summary

GitHub release downloads are slow for the ~1.6 GB OS image, which makes the
desktop flasher painful to use. This adds CI that mirrors each release's assets
to the Hugging Face **dataset** [`pollen-robotics/reachy-mini-os`](https://huggingface.co/datasets/pollen-robotics/reachy-mini-os)
(xet/LFS CDN, much faster), and publishes a `latest.json` manifest the flasher
reads to know what to download.

- `.github/workflows/mirror-to-hf.yml` - mirror workflow
- `.github/scripts/mirror_to_hf.py` - downloads the release assets and uploads them to HF under `<tag>/<filename>`, then writes `latest.json`

## How it triggers

- `workflow_run` after **Generate ReachyMini OS Image** completes successfully.
  A release published by the default `GITHUB_TOKEN` (as `action-gh-release` does)
  does **not** emit a `release` event, so we key off the build workflow instead.
- `workflow_dispatch` with an optional `tag` input, to backfill an existing tag.

## What lands on HF

```
<tag>/<image>.zip        # or .img.gz / .img
<tag>/<image>.bmap
<tag>/<image>.info
latest.json              # { tag, image, bmap, image_size }
```

Idempotent: assets already present for a tag are skipped, so re-runs are cheap.

## Required setup

Add a repo secret **`HF_TOKEN`** = a Hugging Face write token allowed to push to
the `pollen-robotics/reachy-mini-os` dataset (the workflow creates the dataset on
first run if missing).

## Test plan

- [ ] Add the `HF_TOKEN` secret.
- [ ] Run the workflow manually (Actions -> "Mirror release to Hugging Face" -> Run workflow) with `tag = v0.2.7` to backfill.
- [ ] Verify `latest.json` and `v0.2.7/*` appear on the HF dataset.
- [ ] Confirm a subsequent tag build auto-mirrors via `workflow_run`.

Made with [Cursor](https://cursor.com)